### PR TITLE
Feat/#92 : 임시 알림 소켓 생성

### DIFF
--- a/server/gateway/src/socket/notification/notification.gateway.ts
+++ b/server/gateway/src/socket/notification/notification.gateway.ts
@@ -1,0 +1,76 @@
+import {
+  ConnectedSocket,
+  MessageBody,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+
+@WebSocketGateway({
+  namespace: '/socket/notification',
+  cors: {
+    origin: '*',
+    credential: true,
+  },
+})
+class NotificationGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  server: Server;
+
+  notification = {
+    email: '',
+  };
+
+  @SubscribeMessage('join-notification')
+  joinNotification(@ConnectedSocket() socket: Socket, @MessageBody() data) {
+    try {
+      const { email } = data;
+      this.notification[email] = socket.id;
+    } catch (err) {
+      this.server
+        .to(socket.id)
+        .emit('join-fail', { message: '연결에 실패하였습니다.' });
+    }
+  }
+
+  @SubscribeMessage('get-notification')
+  getNotification(@ConnectedSocket() socket: Socket, @MessageBody() data) {
+    const test = {
+      result: [
+        {
+          room: '12345',
+          message: 'BTS 방이 생성되었어요',
+          read: true,
+          date: Date.now(),
+        },
+        {
+          room: '123',
+          message: '아이즈원이 기다리고 있어요',
+          read: false,
+          date: Date.now(),
+        },
+      ],
+    };
+    this.server.emit('set-notification', test);
+  }
+
+  @SubscribeMessage('send-room-notification')
+  roomNotification(@ConnectedSocket() socket: Socket, @MessageBody() data) {
+    const test = {
+      room: '12345',
+      message: 'BTS 방이 생성되었어요 BTS가 기다리는 곳으로 오세요',
+    };
+    socket.emit('receive-room-notification', test);
+  }
+
+  // 소켓 연결이 생성되면
+  handleConnection(@ConnectedSocket() socket: Socket): void {}
+
+  // 소켓 연결이 끊기면 실행
+  handleDisconnect(@ConnectedSocket() socket: Socket) {}
+}
+
+export { NotificationGateway };


### PR DESCRIPTION
## 📕 Issue Number

resolved #92

## 📙 작업 개요

- [x] Gateway에서 임시 Mock 알림 소켓 제작
- [x] Mock response request 호출
- API 명세 : https://thorn-tiara-c85.notion.site/socket-notification-e41fb78e114444dd88062d427c8e1b7e

## 📋 체크리스트

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
