### PR TITLE
Fix/#141 Artist 목록 조회 시, 요청한 사용자의 구독 정보

### DIFF
--- a/server/gateway/src/api/auth/auth.controller.ts
+++ b/server/gateway/src/api/auth/auth.controller.ts
@@ -47,8 +47,9 @@ export class AuthController {
   }
 
   @Get('/artist')
-  async getAllArtist() {
-    return this.authService.getAllArtist();
+  @UseGuards(JwtAuthGuard)
+  async getAllArtist(@Req() { user }) {
+    return this.authService.getAllArtist(user.id);
   }
 
   @Get('/artist/favorite')

--- a/server/gateway/src/api/auth/auth.service.ts
+++ b/server/gateway/src/api/auth/auth.service.ts
@@ -28,8 +28,8 @@ export class AuthService {
     return this.authClient.send({ cmd: 'createArtist' }, createArtistDto);
   }
 
-  public getAllArtist() {
-    return this.authClient.send({ cmd: 'getAllArtist' }, {});
+  public getAllArtist(userId: number) {
+    return this.authClient.send({ cmd: 'getAllArtist' }, userId);
   }
 
   public getFavoriteArtist(userId: number) {

--- a/server/services/auth/src/domain/artist/artist.controller.ts
+++ b/server/services/auth/src/domain/artist/artist.controller.ts
@@ -18,8 +18,8 @@ export class ArtistController {
   }
 
   @MessagePattern({ cmd: 'getAllArtist' })
-  async getAllArtist(): Promise<Artist[]> {
-    return this.artistService.findAll();
+  async getAllArtist(@Payload() userId: number): Promise<Artist[]> {
+    return this.artistService.findAll(userId);
   }
 
   @MessagePattern({ cmd: 'getFavoriteArtist' })

--- a/server/services/auth/src/domain/artist/artist.service.ts
+++ b/server/services/auth/src/domain/artist/artist.service.ts
@@ -41,8 +41,16 @@ export class ArtistService {
     });
   }
 
-  findAll(): Promise<Artist[]> {
-    return this.prisma.artist.findMany();
+  async findAll(userId: number) {
+    const artists = await this.prisma.artist.findMany({
+      include: { favorites: { where: { userId } } },
+    });
+
+    return artists.reduce((acc, artist) => {
+      const { favorites, ...rest } = artist;
+      acc.push({ ...rest, isFavorite: favorites.length > 0 });
+      return acc;
+    }, []);
   }
 
   async findFavoritesByUserId(userId: number): Promise<Artist[]> {


### PR DESCRIPTION
## 📕 Issue Number

> ex) resolved #141

## 📙 작업 개요

> 작업 내용에 대한 개요

- [x] `GET /auth/artist`: artist 목록 조회 시, 요청한 사용자의 구독 정보 추가
 
## 📘 작업 내역

> 작업 내용에 대한 세부 설명

### artist 목록 조회 시, 요청한 사용자의 구독 정보 추가

요청한 사용자가 1, 3 artist를 favorite에 추가한 경우 response

```
[
    {
        "id": 1,
        "name": "Test artist name",
        "profileUrl": null,
        "isFavorite": true
    },
    {
        "id": 2,
        "name": "artist2",
        "profileUrl": null,
        "isFavorite": false
    },
    {
        "id": 3,
        "name": "artist3",
        "profileUrl": null,
        "isFavorite": true
    },
    {
        "id": 4,
        "name": "활동명테스트",
        "profileUrl": "url",
        "isFavorite": false
    }
]
```
## 📋 체크리스트

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📝 PR 특이 사항

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점
