### PR TITLE
Fix/#148 Artist list 조회 시, 로그인 여부 상관없이 결과값 받도록 수정

### DIFF
--- a/server/gateway/src/api/auth/auth.controller.ts
+++ b/server/gateway/src/api/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
   Req,
   UseFilters,
   UseGuards,
@@ -55,9 +56,8 @@ export class AuthController {
   }
 
   @Get('/artist')
-  @UseGuards(JwtAuthGuard)
-  async getAllArtist(@Req() { user }) {
-    return this.authService.getAllArtist(user.id);
+  async getAllArtist(@Query('userId') userId: number | null) {
+    return this.authService.getAllArtist(userId);
   }
 
   @Get('/artist/favorite')

--- a/server/services/auth/src/domain/artist/artist.service.ts
+++ b/server/services/auth/src/domain/artist/artist.service.ts
@@ -41,13 +41,18 @@ export class ArtistService {
     });
   }
 
-  async findAll(userId: number) {
+  async findAll(userId: number | null) {
+    if (!userId) {
+      return this.prisma.artist.findMany();
+    }
+
     const artists = await this.prisma.artist.findMany({
       include: { favorites: { where: { userId } } },
     });
 
     return artists.reduce((acc, artist) => {
       const { favorites, ...rest } = artist;
+      console.log(artist);
       acc.push({ ...rest, isFavorite: favorites.length > 0 });
       return acc;
     }, []);


### PR DESCRIPTION
## 📕 Issue Number

> ex) resolved #148

## 📙 작업 개요

> 작업 내용에 대한 개요

- [x] Artist list 조회 시, 로그인 여부 상관없이 결과값 받도록 수정
 
## 📘 작업 내역

> 작업 내용에 대한 세부 설명

### Artist list 조회 시, 로그인 여부 상관없이 결과값 받도록 수정

request
```
login X
GET /auth/artist

login O
GET /auth/artist?userId=0
```

response
```
login X
[
    {
        "id": 1,
        "name": "Test artist name",
        "profileUrl": null
    },
    {
        "id": 2,
        "name": "artist2",
        "profileUrl": null
    },
    {
        "id": 3,
        "name": "artist3",
        "profileUrl": null
    }
]

login O
[
    {
        "id": 1,
        "name": "Test artist name",
        "profileUrl": null,
        "isFavorite": true
    },
    {
        "id": 2,
        "name": "artist2",
        "profileUrl": null,
        "isFavorite": false
    },
    {
        "id": 3,
        "name": "artist3",
        "profileUrl": null,
        "isFavorite": true
    }
]
```

## 📋 체크리스트

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📝 PR 특이 사항

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점
