### PR TITLE
Fix/#102 user ticket history

### DIFF
--- a/server/services/auth/src/common/constants/config.ts
+++ b/server/services/auth/src/common/constants/config.ts
@@ -1,8 +1,15 @@
 const environment = process.env.NODE_ENV || 'production';
-const AUTH_CONFIG = {
-  NAME: 'AUTH_SERVICE',
-  HOST: environment === 'development' ? 'localhost' : '0.0.0.0', // todo: 배포시에는 서버의 IP로 변경
-  PORT: 3001,
+const MICRO_SERVICES = {
+  AUTH: {
+    NAME: 'AUTH_SERVICE',
+    HOST: environment === 'production' ? 'fanup-auth' : 'localhost',
+    PORT: 3001,
+  },
+  TICKET: {
+    NAME: 'TICKET_SERVICE',
+    HOST: process.env.NODE_ENV === 'production' ? 'fanup-ticket' : 'localhost',
+    PORT: 3003,
+  },
 };
 
-export { AUTH_CONFIG };
+export { MICRO_SERVICES };

--- a/server/services/auth/src/domain/artist/artist.controller.ts
+++ b/server/services/auth/src/domain/artist/artist.controller.ts
@@ -12,7 +12,7 @@ export class ArtistController {
   @MessagePattern({ cmd: 'createArtist' })
   async createArtist(
     @Payload() requestCreateArtistDto: requestCreateArtistDto,
-  ): Promise<Artist> {
+  ): Promise<string> {
     console.log('create artist');
     return this.artistService.create(requestCreateArtistDto);
   }

--- a/server/services/auth/src/domain/artist/artist.module.ts
+++ b/server/services/auth/src/domain/artist/artist.module.ts
@@ -1,11 +1,24 @@
 import { Module } from '@nestjs/common';
+import { ClientsModule, Transport } from '@nestjs/microservices';
+import { MICRO_SERVICES } from 'src/common/constants/config';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { UserService } from '../user/user.service';
 import { ArtistController } from './artist.controller';
 import { ArtistService } from './artist.service';
 
 @Module({
-  imports: [],
+  imports: [
+    ClientsModule.register([
+      {
+        name: MICRO_SERVICES.TICKET.NAME,
+        transport: Transport.TCP,
+        options: {
+          host: MICRO_SERVICES.TICKET.HOST,
+          port: MICRO_SERVICES.TICKET.PORT,
+        },
+      },
+    ]),
+  ],
   controllers: [ArtistController],
   providers: [ArtistService, UserService, PrismaService],
   exports: [ArtistService],

--- a/server/services/auth/src/domain/artist/artist.service.ts
+++ b/server/services/auth/src/domain/artist/artist.service.ts
@@ -1,6 +1,8 @@
-import { HttpStatus, Injectable } from '@nestjs/common';
-import { RpcException } from '@nestjs/microservices';
-import { Artist } from '@prisma/client';
+import { HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { ClientProxy, RpcException } from '@nestjs/microservices';
+import { Artist, User } from '@prisma/client';
+import { firstValueFrom } from 'rxjs';
+import { MICRO_SERVICES } from 'src/common/constants/config';
 import { CustomRpcException } from 'src/common/exception/custom-rpc-exception';
 
 import { PrismaService } from 'src/prisma/prisma.service';
@@ -12,13 +14,16 @@ export class ArtistService {
   constructor(
     private readonly userService: UserService,
     private readonly prisma: PrismaService,
+
+    @Inject(MICRO_SERVICES.TICKET.NAME)
+    private readonly ticketClient: ClientProxy,
   ) {}
 
   async create({
     userId,
     name,
     profileUrl,
-  }: requestCreateArtistDto): Promise<any> {
+  }: requestCreateArtistDto): Promise<string> {
     const user = await this.userService.findOne(userId);
 
     if (user.role !== 'ARTIST') {
@@ -35,10 +40,29 @@ export class ArtistService {
       );
     }
 
-    return this.prisma.user.update({
-      where: { id: userId },
-      data: { artist: { create: { name, profileUrl } } },
-    });
+    let artist = null;
+    try {
+      artist = await this.prisma.artist.create({
+        data: {
+          name,
+          profileUrl,
+          user: {
+            connect: { id: userId },
+          },
+        },
+      });
+      await firstValueFrom(
+        this.ticketClient.send({ cmd: 'createArtist' }, artist),
+      );
+    } catch (e) {
+      console.log('asdfasfsafasdfasdfasdf!!!!!!!!!!!!!!!!!!', e);
+      throw new CustomRpcException(
+        'Cannot create artist',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    return 'artist created';
   }
 
   async findAll(userId: number | null) {

--- a/server/services/auth/src/main.ts
+++ b/server/services/auth/src/main.ts
@@ -3,7 +3,7 @@ import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
 import { AppModule } from './app.module';
 
-import { AUTH_CONFIG } from './common/constants/config';
+import { MICRO_SERVICES } from './common/constants/config';
 import CustomRpcExceptionFilter from './common/exception/filter/custom-rpc-exception.filter';
 
 async function bootstrap() {
@@ -12,8 +12,8 @@ async function bootstrap() {
     {
       transport: Transport.TCP,
       options: {
-        host: AUTH_CONFIG.HOST,
-        port: AUTH_CONFIG.PORT,
+        host: MICRO_SERVICES.AUTH.HOST,
+        port: MICRO_SERVICES.AUTH.PORT,
       },
     },
   );

--- a/server/services/ticket/prisma/schema.prisma
+++ b/server/services/ticket/prisma/schema.prisma
@@ -23,6 +23,7 @@ model Ticket {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   artistId  Int
+  artist    Artist   @relation(fields: [artistId], references: [id])
   salesTime DateTime
   startTime DateTime
   status    Status  @default(OPEN)
@@ -40,4 +41,11 @@ model UserTicket {
   ticket    Ticket   @relation(fields: [ticketId], references: [id])
   createdAt DateTime @default(now())
   fanupId   Int?
+}
+
+model Artist {
+  id          Int     @id
+  name        String
+  profileUrl  String?
+  tickets     Ticket[]
 }

--- a/server/services/ticket/src/app.module.ts
+++ b/server/services/ticket/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ArtistModule } from './domain/artist/artist.module';
 import { TicketModule } from './domain/ticket/ticket.module';
 import { UserTicketModule } from './domain/user-ticket/user-ticket.module';
 import { JobModule } from './job/job.module';
@@ -10,6 +11,7 @@ import { JobModule } from './job/job.module';
 @Module({
   imports: [
     EventEmitterModule.forRoot(),
+    ArtistModule,
     TicketModule,
     UserTicketModule,
     ConfigModule.forRoot({

--- a/server/services/ticket/src/domain/artist/artist.controller.ts
+++ b/server/services/ticket/src/domain/artist/artist.controller.ts
@@ -1,7 +1,17 @@
 import { Controller } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
+import { Artist } from '@prisma/client';
 import { ArtistService } from './artist.service';
 
 @Controller()
 export class ArtistController {
   constructor(private readonly artistService: ArtistService) {}
+
+  @MessagePattern({ cmd: 'createArtist' })
+  async createArtist(
+    @Payload() requestCreateArtistDto: Artist,
+  ): Promise<Artist> {
+    console.log('create artist on ticket service');
+    return this.artistService.create(requestCreateArtistDto);
+  }
 }

--- a/server/services/ticket/src/domain/artist/artist.controller.ts
+++ b/server/services/ticket/src/domain/artist/artist.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { ArtistService } from './artist.service';
+
+@Controller()
+export class ArtistController {
+  constructor(private readonly artistService: ArtistService) {}
+}

--- a/server/services/ticket/src/domain/artist/artist.module.ts
+++ b/server/services/ticket/src/domain/artist/artist.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PrismaService } from 'src/provider/prisma/prisma.service';
+import { ArtistController } from './artist.controller';
+import { ArtistService } from './artist.service';
+
+@Module({
+  providers: [ArtistService, PrismaService],
+  controllers: [ArtistController],
+})
+export class ArtistModule {}

--- a/server/services/ticket/src/domain/artist/artist.service.ts
+++ b/server/services/ticket/src/domain/artist/artist.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/provider/prisma/prisma.service';
+
+@Injectable()
+export class ArtistService {
+  constructor(private readonly prisma: PrismaService) {}
+}

--- a/server/services/ticket/src/domain/artist/artist.service.ts
+++ b/server/services/ticket/src/domain/artist/artist.service.ts
@@ -1,7 +1,14 @@
 import { Injectable } from '@nestjs/common';
+import { Artist } from '@prisma/client';
 import { PrismaService } from 'src/provider/prisma/prisma.service';
 
 @Injectable()
 export class ArtistService {
   constructor(private readonly prisma: PrismaService) {}
+
+  create(createArtistDto: Artist) {
+    return this.prisma.artist.create({
+      data: createArtistDto,
+    });
+  }
 }


### PR DESCRIPTION
## 📕 Issue Number

resolved #102

## 📙 작업 개요

> 작업 내용에 대한 개요

- [x] Artist 정보 연동하여 user ticket history 조회
 
## 📘 작업 내역

> 작업 내용에 대한 세부 설명

### Artist 정보 연동하여 user ticket history 조회

기존 티켓 리스트를 보낼 때, artist 정보 없이 artist Id만 보내는 상황이었다.
이를 해결하고자 다음과 같은 flow를 적용하였다.

1. ticket service에도 artist table을 생성
2. artist table이 위치하는 auth service에서 artist 정보를 생성하는 시점에 ticket service로도 artist 생성 이벤트 전송
3. ticket service에서까지 정상적으로 artist가 생성되었다면 return

다만 auth service에서는 성공적으로 artist를 생성하고, ticket service에서 실패하는 경우에 rollback을 지원하지 않아 두 db 간 동기화가 되지 않을 가능성이 존재한다. 이를 해결하기 위한 추가적인 로직이 필요해보인다.

## 📋 체크리스트

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📝 PR 특이 사항

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점
