### PR TITLE
Fix: ticket 단건 조회 시, artist 정보 추가

### DIFF
--- a/server/services/ticket/src/domain/ticket/ticket.service.ts
+++ b/server/services/ticket/src/domain/ticket/ticket.service.ts
@@ -36,6 +36,7 @@ export class TicketService {
     try {
       return await this.prisma.ticket.findUniqueOrThrow({
         where: { id: ticketId },
+        include: { artist: true },
       });
     } catch (e) {
       throw new CustomRpcException('Ticket not found', HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
## 📕 Issue Number

resolved #175

## 📙 작업 개요

> 작업 내용에 대한 개요

- [x] ticket 단건 조회 시, artist 정보 추가
 
## 📘 작업 내역

> 작업 내용에 대한 세부 설명

### ticket 단건 조회 시, artist 정보 추가

request
```
GET /ticket/:ticketId
```

response

```
{
    "id": 1,
    "title": "산타",
    "content": "왔다.",
    "createdAt": "2022-12-13T07:14:31.094Z",
    "updatedAt": "2022-12-13T07:14:31.094Z",
    "artistId": 2,
    "salesTime": "2022-12-13T07:15:00.000Z",
    "startTime": "2022-12-21T05:00:00.000Z",
    "status": "OPEN",
    "totalAmount": 10,
    "numberTeam": 1,
    "timeTeam": 1,
    "price": 1,
    "artist": {
        "id": 2,
        "name": "루돌프",
        "profileUrl": "https://file-storage.kr.object.ncloudstorage.com/1670915621462-2bff44c3-3c76-447d-a0e1-d95d70314fc1.jpeg"
    }
}
```

## 📋 체크리스트

> PR 전 체크해주세요.

- [x] Merge 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [ ] PR 내용이 정상 동작한다는 것을 보증하는 **테스트**를 추가하였는가?

## 📝 PR 특이 사항

> 팀원이 코드리뷰 시 주의할 점 또는 말하고 싶은 점
